### PR TITLE
faster docker builds

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -16,10 +16,8 @@ ENV PYTHONUNBUFFERED 1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc
 
-RUN pip install --upgrade pip
-COPY . /usr/src/app/
-
 # install python dependencies
+RUN pip install --upgrade pip
 COPY ./requirements.txt .
 RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/app/wheels -r requirements.txt
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -74,6 +74,5 @@ keepalive = 2
 capture_output = True
 logger_class = logging_setup.GunicornLogger
 errorlog = "-"
-loglevel = "debug"
 accesslog = "-"
 access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'


### PR DESCRIPTION
- Backup changes
- Freeze requirements for Docker install
- Modify poetry command to run flask app
- Monkey patch eventlet for flask-socketio
- Improved logging
- Add Dockerfile and boot script
- Change logging output and loglevel
- Make Flask use Gunicorn logger
- Replace print statement by logging
- Bump nox from 2021.10.1 to 2022.1.7 in /.github/workflows
- Bump pypa/gh-action-pypi-publish from 1.4.2 to 1.5.0
- Working dockerized version with gunicorn and nginx
- Change for port 8000
- Remove flaskenv
- Remove boot.sh
- Remove old docker-compose
- Remove old dockerfile
- Remove deprecated entrypoint
- Split CMD into ENTRYPOINT and CMD
- Add documentation
- Add structlog dependency
- Freeze requirements
- Add structlog dependency
- Configure nginx logging
- Add Gunicorn config file
- Update Dockerfile
- Clean logging setup
- Document gunicorn conf file
- Add rich to dependencies
- Add rich to prod dependencies
- Export requirements with rich dependency
- Configured logger for routes module
- Fix gunicorn config file. Gunicorn and Flask app use structlog for logging
- Add new app logger
- Configure the 3 loggers
- Use the "app" logger
- Documentation and code clean up
- Documentation and code clean up
- Move Gunicorn command from Dockerfile to gunicorn conf file
- Bump release-drafter/release-drafter from 5.15.0 to 5.16.1
- Remove duplicate argument from Dockerfile
- Add Gunicorn to dependencies
- Add Gunicorn to requirements
- Add logging_setup to Dockerfile
- Create logging_setup to centralize loggers configuration
- Move all logger-related things to logging_setup file
- Update to match new logging setup
- Use new logging setup
- Bump flake8-bugbear from 21.11.29 to 22.1.11
- Bump mypy from 0.930 to 0.931
- Remove loglevel parameter
- Remove app from builder image for faster builds
